### PR TITLE
Remove deprecated API

### DIFF
--- a/scripts/bookinfo.yaml
+++ b/scripts/bookinfo.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
@@ -63,7 +63,7 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
@@ -114,7 +114,7 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1


### PR DESCRIPTION
Per https://www.ibm.com/cloud/blog/announcements/kubernetes-version-1-16-removes-deprecated-apis